### PR TITLE
[Discuss] XDefi <> Rootstock integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This library currently supports the following blockchain networks:
 | Ethereum        | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
 | BNB Smart Chain | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
 | Polygon         | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
+| Rootstock       | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
 | Avalanche       | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
 | Fantom          | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |
 | Arbitrum        | [EVM](https://github.com/XDeFi-tech/chains/pkgs/npm/chains-evm)                 | Indexer, Chain | SeedPhrase, PrivateKey, Ledger, Trezor | Yes          |

--- a/packages/evm/src/datasource/indexer/gql/rootstock.graphql
+++ b/packages/evm/src/datasource/indexer/gql/rootstock.graphql
@@ -1,0 +1,85 @@
+query GetRootstockBalance($address: String!) {
+  rootstock {
+    balances(address: $address) {
+      address
+      asset {
+        symbol
+        contract
+        id
+        name
+        image
+        chain
+        decimals
+        price {
+          amount
+          dayPriceChange
+        }
+      }
+      amount {
+        value
+      }
+    }
+  }
+}
+
+query RootstockDefaultGasFees {
+  rootstock {
+    fee {
+      high
+      low
+      medium
+    }
+  }
+}
+
+query GetRootstockTransactions($address: String!, $first: Int) {
+  rootstock {
+    transactions(address: $address, first: $first) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          hash
+          blockIndex
+          blockNumber
+          status
+          value
+          timestamp
+          fromAddress
+          transfers {
+            amount {
+              value
+            }
+            asset {
+              ... on CryptoAsset {
+                chain
+                contract
+                decimals
+                id
+                image
+                name
+                price {
+                  amount
+                  scalingFactor
+                }
+                symbol
+              }
+            }
+            fromAddress
+            toAddress
+          }
+        }
+      }
+    }
+  }
+}
+
+query GetRootstockStatus {
+  rootstock {
+    status {
+      lastBlock
+    }
+  }
+}

--- a/packages/evm/src/manifests.ts
+++ b/packages/evm/src/manifests.ts
@@ -12,6 +12,7 @@ export enum EVMChains {
   optimism = 'optimism',
   klaytn = 'klaytn',
   cronos = 'cronos',
+  rootstock = 'rootstock',
 }
 
 export const EVM_MANIFESTS: { [key in EVMChains]: Chain.Manifest } = {
@@ -57,6 +58,23 @@ export const EVM_MANIFESTS: { [key in EVMChains]: Chain.Manifest } = {
     blockExplorerURL: 'https://polygonscan.com',
     chainId: '137',
     chain: 'polygon',
+    decimals: 18,
+    feeGasStep: {
+      high: 1.5,
+      medium: 1.25,
+      low: 1,
+    },
+    multicallContractAddress: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    maxGapAmount: 0,
+  },
+  [EVMChains.rootstock]: {
+    name: 'Rootstock',
+    description: 'EVM compatible bitcoin sidechain',
+    rpcURL: 'https://public-node.rsk.co',
+    chainSymbol: 'RBTC',
+    blockExplorerURL: 'https://explorer.rootstock.io',
+    chainId: '30',
+    chain: 'rootstock',
     decimals: 18,
     feeGasStep: {
       high: 1.5,


### PR DESCRIPTION
## Description
This is kickstart PR to discuss the key requirement for Rootstock integration with XDefi chains lib. Rootstock is a fully EVM compatible chain. So the existing EVM implementation would work for rootstock with minor changes. Added rootstock chain configurations in EVM_MANIFESTS. 

## Requirement

To move forward with the Rootstock integration first rootstock needs to be indexed at: https://gql-router.xdefi.services/graphql 

Let me know to whom should i contact for the indexer integration.

## About Rootstock 

Website: https://rootstock.io/
Defillama: https://defillama.com/chain/Rootstock
Explorer: https://explorer.rootstock.io/
Developer portal: https://dev.rootstock.io/
